### PR TITLE
avoid Uncaught SyntaxError of 'querySelector'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mobilebone",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Bone main for mobile web APP with a sigle page mode.",
   "main": "src/mobilebone.js",
   "directories": {

--- a/src/mobilebone.js
+++ b/src/mobilebone.js
@@ -38,7 +38,7 @@
 	 *
 	 * @type string
 	**/
-	Mobilebone.VERSION = '2.3.2';
+	Mobilebone.VERSION = '2.3.3';
 	
 	/**
 	 * Whether catch attribute of href from element with tag 'a'
@@ -1029,13 +1029,14 @@
 	 * page change when history change
 	**/
 	window.addEventListener("popstate", function() {
-		console.log(history.popstate);
+		
 		if (history.popstate == false) {
 			history.popstate = true;
 			return;
 		}
 		
-		var hash = location.hash.replace("#&", "").replace("#", ""), page_in = null;
+		var hash = location.hash.replace("#&", "").replace(/^#/, ""), page_in = null;
+		
 		if (hash == "") {
 			// if no hash, get first page as 'page_in'
 			page_in = document.querySelector("." + Mobilebone.classPage);
@@ -1045,7 +1046,7 @@
 		}
 		
 		if (!page_in) {
-			if(isSimple.test(hash) == false) {
+			if(isSimple.test(hash) == false || (/&/.test(hash) == true)) {
 				// as a url
 				Mobilebone.ajax({
 					url: hash,

--- a/test/ajax-html/index.html
+++ b/test/ajax-html/index.html
@@ -13,10 +13,10 @@
 <div id="pageHome" class="page out">
     <ul>
         <li><a href="ajax-page.html" data-container="container">点击加载(缓存，若后2项已请求，则无请求)</a></li>
-        <li><a href="ajax-page.html" data-reload>点击加载(每次都请求， 返回含page结构)</a></li>
+        <li><a href="ajax-page.html#a=1#b=1&c=1#" data-reload>点击加载(每次都请求， 返回含page结构)</a></li>
         <li><a href="ajax-page.html?&&" data-formdata="?a=1">点击加载(缓存, url过滤测试)</a></li>
         <li><a href="ajax-page.html?a" data-reload data-formdata="?a=1">点击加载(data-formdata测试)-全覆盖loading</a></li>
-        <li><a href="ajax-page.html?a=1&" data-reload data-formdata="&c=1" data-mask="true">点击加载(data-formdata测试)-内覆盖loading</a></li>
+        <li><a href="ajax-page.html?a=1&#tt_fo#nt=m&tt_#daymode=1" data-reload data-formdata="&c=1" data-mask="true">点击加载(data-formdata测试)-内覆盖loading</a></li>
         <li><a href="ajax-page.html?a=1&b=" class="follow" data-reload data-formdata="c=1&d=1" data-mask="true">点击加载(data-formdata测试)-跟随loading</a></li>
     </ul>
     <ul>


### PR DESCRIPTION
muli '#' may cause  Failed to execute 'querySelector'  error